### PR TITLE
ES modules + browser build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+flatbush.js
+flatbush.min.js
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ var found = index.search(minX, minY, maxX, maxY).map((i) => items[i]);
 
 ```
 
+## Install
+
+Install using NPM (`npm install flatbush`) or Yarn (`yarn add flatbush`), then either:
+
+```js
+// require in Node / Browserify
+var flatbush = require('flatbush');
+
+// or import as a ES module
+import flatbush from 'flatbush';
+```
+
+Or use a browser build directly:
+
+```html
+<script src="https://unpkg.com/flatbush@1.3.0/flatbush.min.js"></script>
+```
+
 ## API
 
 #### flatbush(numItems[, nodeSize, ArrayType])
@@ -68,7 +86,7 @@ var ids = index.search(10, 10, 20, 20, (i) => items[i].foo === 'bar');
 
 ## Performance
 
-Running `node bench.js`:
+Running `npm run bench`:
 
 ```
 1000000 rectangles

--- a/bench.js
+++ b/bench.js
@@ -1,6 +1,5 @@
-'use strict';
 
-var flatbush = require('./');
+var flatbush = require('./index.js').default;
 var rbush = require('rbush');
 
 var N = 1000000;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
-'use strict';
 
-module.exports = flatbush;
-
-function flatbush(numItems, nodeSize, ArrayType) {
+export default function flatbush(numItems, nodeSize, ArrayType) {
     return new Flatbush(numItems, nodeSize, ArrayType);
 }
 

--- a/package.json
+++ b/package.json
@@ -2,17 +2,33 @@
   "name": "flatbush",
   "version": "1.2.0",
   "description": "Fast static spatial index for rectangles",
-  "main": "index.js",
+  "main": "flatbush.js",
+  "module": "index.js",
+  "jsnext:main": "index.js",
+  "unpkg": "flatbush.min.js",
+  "jsdelivr": "flatbush.min.js",
   "scripts": {
-    "pretest": "eslint *.js",
-    "test": "tape test.js"
+    "pretest": "eslint index.js test.js bench.js",
+    "test": "tape -r @std/esm test.js",
+    "bench": "node -r @std/esm bench.js",
+    "build": "rollup index.js --o flatbush.js -f umd --name flatbush && uglifyjs flatbush.js -c -m -o flatbush.min.js",
+    "prepare": "npm run build"
   },
+  "files": [
+    "index.js",
+    "flatbush.js",
+    "flatbush.min.js"
+  ],
+  "@std/esm": "js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mourner/flatbush.git"
   },
   "eslintConfig": {
-    "extends": "mourner"
+    "extends": "mourner",
+    "parserOptions": {
+      "sourceType": "module"
+    }
   },
   "keywords": [
     "geometry",
@@ -29,9 +45,12 @@
   },
   "homepage": "https://github.com/mourner/flatbush#readme",
   "devDependencies": {
+    "@std/esm": "^0.23.3",
     "eslint": "^4.18.1",
     "eslint-config-mourner": "^2.0.3",
     "rbush": "^2.0.2",
-    "tape": "^4.9.0"
+    "rollup": "^0.56.3",
+    "tape": "^4.9.0",
+    "uglify-js": "^3.3.12"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,12 +4,11 @@
   "description": "Fast static spatial index for rectangles",
   "main": "flatbush.js",
   "module": "index.js",
-  "jsnext:main": "index.js",
   "unpkg": "flatbush.min.js",
   "jsdelivr": "flatbush.min.js",
   "scripts": {
     "pretest": "eslint index.js test.js bench.js",
-    "test": "tape -r @std/esm test.js",
+    "test": "node -r @std/esm test.js",
     "bench": "node -r @std/esm bench.js",
     "build": "rollup index.js --o flatbush.js -f umd --name flatbush && uglifyjs flatbush.js -c -m -o flatbush.min.js",
     "prepare": "npm run build"

--- a/test.js
+++ b/test.js
@@ -1,6 +1,5 @@
-'use strict';
 
-var flatbush = require('./');
+var flatbush = require('./index.js').default;
 var test = require('tape').test;
 
 var data = [


### PR DESCRIPTION
Turn `flatbush` into a proper ES module, and set up browser builds for publishing.