### PR TITLE
decouple indices from coordinates

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,15 +20,12 @@ export default class Flatbush {
         } while (n !== 1);
 
         this.ArrayType = ArrayType || Float64Array;
-        this.IndexArrayType = Float64Array;
+        this.IndexArrayType = Uint32Array;
         if (numNodes * 4 < Math.pow(2, 8)) {
             this.IndexArrayType = Uint8Array;
         } else if (numNodes * 4 < Math.pow(2, 16)) {
             this.IndexArrayType = Uint16Array;
-        } else if (numNodes * 4 < Math.pow(2, 32)) {
-            this.IndexArrayType = Uint32Array;
         }
-        const alignmentMargin = (this.IndexArrayType.BYTES_PER_ELEMENT - numNodes * 4 * this.ArrayType.BYTES_PER_ELEMENT % this.IndexArrayType.BYTES_PER_ELEMENT) % this.IndexArrayType.BYTES_PER_ELEMENT;
 
         if (data) {
             if (data instanceof ArrayBuffer) {
@@ -38,7 +35,7 @@ export default class Flatbush {
             }
             this._boxes = new this.ArrayType(this.data, 0, numNodes * 4);
             this._indices = new this.IndexArrayType(this.data,
-                numNodes * 4 * this.ArrayType.BYTES_PER_ELEMENT + alignmentMargin,
+                numNodes * 4 * this.ArrayType.BYTES_PER_ELEMENT,
                 numNodes);
 
             this._numAdded = numItems;
@@ -50,10 +47,10 @@ export default class Flatbush {
 
         } else {
             this.data = new ArrayBuffer(numNodes * 4 * this.ArrayType.BYTES_PER_ELEMENT +
-                alignmentMargin + numNodes * this.IndexArrayType.BYTES_PER_ELEMENT);
+                numNodes * this.IndexArrayType.BYTES_PER_ELEMENT);
             this._boxes = new this.ArrayType(this.data, 0, numNodes * 4);
             this._indices = new this.IndexArrayType(this.data,
-                numNodes * 4 * this.ArrayType.BYTES_PER_ELEMENT + alignmentMargin,
+                numNodes * 4 * this.ArrayType.BYTES_PER_ELEMENT,
                 numNodes);
             this._numAdded = 0;
             this._pos = 0;

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ export default class Flatbush {
         } else if (numNodes * 4 < Math.pow(2, 32)) {
             this.IndexArrayType = Uint32Array;
         }
-        const alignmentMargin = Math.max(0, this.IndexArrayType.BYTES_PER_ELEMENT - 4 * this.ArrayType.BYTES_PER_ELEMENT);
+        const alignmentMargin = (this.IndexArrayType.BYTES_PER_ELEMENT - numNodes * 4 * this.ArrayType.BYTES_PER_ELEMENT % this.IndexArrayType.BYTES_PER_ELEMENT) % this.IndexArrayType.BYTES_PER_ELEMENT;
 
         if (data) {
             if (data instanceof ArrayBuffer) {

--- a/test.js
+++ b/test.js
@@ -37,9 +37,10 @@ function createIndex() {
 test('indexes a bunch of rectangles', (t) => {
     const index = createIndex();
 
-    const len = index.data.length;
-    t.equal(len, 540);
-    t.same(index.data.subarray(len - 5, len), [500, 0, 1, 96, 95]);
+    const len = index._boxes.length;
+    t.equal(index._boxes.length + index._indices.length, 540);
+    t.same(index._boxes.subarray(len - 4, len), [0, 1, 96, 95]);
+    t.same(index._indices[len / 4 - 1], 400);
 
     t.end();
 });


### PR DESCRIPTION
This allows to use an independent array type for indices (which are always unsigned integers for which the smallest fitting type is automatically chosen).

Follows the discusion in https://github.com/mourner/flatbush/pull/4#issuecomment-383980084