### PR TITLE
Add a header to make it easier to reconstruct the index

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,6 @@ export default class Flatbush {
             this._boxes = new this.ArrayType(this.data, 8, numNodes * 4);
             this._indices = new this.IndexArrayType(this.data, 8 + nodesByteSize, numNodes);
 
-            this._numAdded = numItems;
             this._pos = numNodes * 4;
             this.minX = this._boxes[this._pos - 4];
             this.minY = this._boxes[this._pos - 3];
@@ -50,7 +49,6 @@ export default class Flatbush {
             this.maxY = this._boxes[this._pos - 1];
 
         } else {
-            this._numAdded = 0;
             this.data = new ArrayBuffer(8 + nodesByteSize + numNodes * this.IndexArrayType.BYTES_PER_ELEMENT);
             this._boxes = new this.ArrayType(this.data, 8, numNodes * 4);
             this._indices = new this.IndexArrayType(this.data, 8 + nodesByteSize, numNodes);
@@ -67,7 +65,8 @@ export default class Flatbush {
     }
 
     add(minX, minY, maxX, maxY) {
-        this._indices[this._numAdded] = this._numAdded++;
+        const index = this._pos >> 2;
+        this._indices[index] = index;
         this._boxes[this._pos++] = minX;
         this._boxes[this._pos++] = minY;
         this._boxes[this._pos++] = maxX;
@@ -80,8 +79,8 @@ export default class Flatbush {
     }
 
     finish() {
-        if (this._numAdded !== this.numItems) {
-            throw new Error('Added ' + this._numAdded + ' items when expected ' + this.numItems);
+        if (this._pos >> 2 !== this.numItems) {
+            throw new Error('Added ' + (this._pos >> 2) + ' items when expected ' + this.numItems);
         }
 
         const width = this.maxX - this.minX;

--- a/index.js
+++ b/index.js
@@ -46,9 +46,14 @@ export default class Flatbush {
         this.ArrayType = ArrayType || Float64Array;
         this.IndexArrayType = numNodes < 16384 ? Uint16Array : Uint32Array;
 
+        const arrayTypeIndex = ARRAY_TYPES.indexOf(this.ArrayType);
         const nodesByteSize = numNodes * 4 * this.ArrayType.BYTES_PER_ELEMENT;
 
-        if (data) {
+        if (arrayTypeIndex < 0) {
+            throw new Error(`Unexpected typed array class: ${ArrayType}.`);
+        }
+
+        if (data && (data instanceof ArrayBuffer)) {
             this.data = data;
             this._boxes = new this.ArrayType(this.data, 8, numNodes * 4);
             this._indices = new this.IndexArrayType(this.data, 8 + nodesByteSize, numNodes);
@@ -69,7 +74,7 @@ export default class Flatbush {
             this.maxX = -Infinity;
             this.maxY = -Infinity;
 
-            new Uint8Array(this.data, 0, 2).set([0xfb, (VERSION << 4) + ARRAY_TYPES.indexOf(this.ArrayType)]);
+            new Uint8Array(this.data, 0, 2).set([0xfb, (VERSION << 4) + arrayTypeIndex]);
             new Uint16Array(this.data, 2, 1)[0] = nodeSize;
             new Uint32Array(this.data, 4, 1)[0] = numItems;
         }

--- a/test.js
+++ b/test.js
@@ -65,7 +65,7 @@ test('performs bbox search', (t) => {
 
 test('reconstructs an index from array buffer', (t) => {
     const index = createIndex();
-    const index2 = new Flatbush(data.length / 4, 16, Float64Array, index.data);
+    const index2 = Flatbush.from(index.data);
 
     t.same(index, index2);
     t.end();


### PR DESCRIPTION
Closes #12. Allows you to do `const index = Flatbush.from(data)` by encoding the number of items, the node size and the array type into the buffer (as an 8-byte header).