### PR TITLE
Skip sorting when there is only one node

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,6 +106,15 @@ export default class Flatbush {
             throw new Error(`Added ${this._pos >> 2} items when expected ${this.numItems}.`);
         }
 
+        if (this.numItems <= this.nodeSize) {
+            // only one node, skip sorting and just fill the root box
+            this._boxes[this._pos++] = this.minX;
+            this._boxes[this._pos++] = this.minY;
+            this._boxes[this._pos++] = this.maxX;
+            this._boxes[this._pos++] = this.maxY;
+            return;
+        }
+
         const width = this.maxX - this.minX;
         const height = this.maxY - this.minY;
         const hilbertValues = new Uint32Array(this.numItems);


### PR DESCRIPTION
If numItems <= nodeSize then there is no reason to perform the Hilbert index sort since there is only the root box and one node/tier of boxes below it.

For many use cases this wont provide a meaningful performance gain. However, in the case of repeated and varied input counts for which many may be smaller than nodeSize it is significant (I am seeing around 25-40% increase in speed for some of my use cases in c++), and it comes at almost no cost (a single compare) in the case of larger input counts.

