### PR TITLE
Stop quicksort earlier for faster indexing

### DIFF
--- a/bench.js
+++ b/bench.js
@@ -43,6 +43,8 @@ for (let i = 0; i < coords.length; i += 4) {
 index.finish();
 console.timeEnd('flatbush');
 
+console.log(`index size: ${index.data.byteLength.toLocaleString()}`);
+
 function benchSearch(boxes, name, warmup) {
     const id = `${K} searches ${name}`;
     if (!warmup) console.time(id);

--- a/index.js
+++ b/index.js
@@ -124,7 +124,7 @@ export default class Flatbush {
         }
 
         // sort items by their Hilbert value (for packing later)
-        sort(hilbertValues, this._boxes, this._indices, 0, this.numItems - 1);
+        sort(hilbertValues, this._boxes, this._indices, 0, this.numItems - 1, this.nodeSize);
 
         // generate nodes at each tree level, bottom-up
         for (let i = 0, pos = 0; i < this._levelBounds.length - 1; i++) {
@@ -276,9 +276,9 @@ function upperBound(value, arr) {
     return arr[i];
 }
 
-// custom quicksort that sorts bbox data alongside the hilbert values
-function sort(values, boxes, indices, left, right) {
-    if (left >= right) return;
+// custom quicksort that partially sorts bbox data alongside the hilbert values
+function sort(values, boxes, indices, left, right, nodeSize) {
+    if (Math.floor(left / nodeSize) >= Math.floor(right / nodeSize)) return;
 
     const pivot = values[(left + right) >> 1];
     let i = left - 1;
@@ -291,8 +291,8 @@ function sort(values, boxes, indices, left, right) {
         swap(values, boxes, indices, i, j);
     }
 
-    sort(values, boxes, indices, left, j);
-    sort(values, boxes, indices, j + 1, right);
+    sort(values, boxes, indices, left, j, nodeSize);
+    sort(values, boxes, indices, j + 1, right, nodeSize);
 }
 
 // swap two values and two corresponding boxes

--- a/test.js
+++ b/test.js
@@ -110,8 +110,8 @@ test('k-nearest-neighbors query accepts maxDistance', (t) => {
 
 test('k-nearest-neighbors query accepts filterFn', (t) => {
     const index = createIndex();
-    const ids = index.neighbors(50, 50, 5, Infinity, i => i % 2 === 0);
-    t.same(ids.sort(compare), [6, 16, 18, 24, 54].sort(compare));
+    const ids = index.neighbors(50, 50, 6, Infinity, i => i % 2 === 0);
+    t.same(ids.sort(compare), [6, 16, 18, 24, 54, 80].sort(compare));
     t.end();
 });
 


### PR DESCRIPTION
Instead of doing a full sort of the nodes, only sort them until we recurse down to values within a node (which don't have to be sorted), and stop there. Slightly improves performance of indexing, especially for higher `nodeSize` values. For the default (`16`), it seems to improve indexing by ~5–8%. The only gotcha was that it changes the return order in kNN queries for equal-distance items (hence the test update), but this should be fine.

@jbuckmccready your #28 PR got me the idea, check it out.