### PR TITLE
Use in-place radix sort instead of quicksort

### DIFF
--- a/index.js
+++ b/index.js
@@ -320,11 +320,12 @@ function sort(arr, boxes, indices, start, end, nodeSize, shift) {
     for (let x = 0; x < 256; ++x) {
         const i = x > 0 ? ptr[x - 1] : start;
         const j = ptr[x];
-        if (Math.floor(i / nodeSize) >= Math.floor((j - 1) / nodeSize)) return;
-        if (j - i > 64) {
-            sort(arr, boxes, indices, i, j, nodeSize, shift - 8);
-        } else {
-            insertionSort(arr, boxes, indices, i, j);
+        if (Math.floor(i / nodeSize) < Math.floor((j - 1) / nodeSize)) {
+            if (j - i > 64) {
+                sort(arr, boxes, indices, i, j, nodeSize, shift - 8);
+            } else {
+                insertionSort(arr, boxes, indices, i, j);
+            }
         }
     }
 }


### PR DESCRIPTION
An experiment that adapts MSD in-place radix sort from [this article](https://erik.gorset.no/2011/04/radix-sort-is-faster-than-quicksort.html) to Flatbush, replacing quick sort. Closes #30. cc @jbuckmccready

Makes indexing large amounts of data faster, while being slower on small amounts. A few quick results:

- 10 million: ~40% faster
- 1 million: ~15% faster
- 100k: ~15% slower

Not sure why the smaller amounts are slower... Perhaps we could include both sorts and pick one that's faster based on the number of items. Although this would make this project's code quite a bite more complicated and verbose, and I'm not sure whether this is a good tradeoff.