### PR TITLE
support adding fewer than numItems via auto-trim()

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,9 +84,6 @@ export default class Flatbush {
             new Uint16Array(this.data, 2, 1)[0] = nodeSize;
             new Uint32Array(this.data, 4, 1)[0] = numItems;
         }
-
-        // a priority queue for k-nearest-neighbors queries
-        this._queue = new FlatQueue();
     }
 
     add(minX, minY, maxX, maxY) {
@@ -132,6 +129,9 @@ export default class Flatbush {
             throw new Error(`Added ${this._pos >> 2} items when expected ${this.numItems}.`);
         }
         const boxes = this._boxes;
+
+        // a priority queue for k-nearest-neighbors queries
+        this._queue = new FlatQueue();
 
         if (this.numItems <= this.nodeSize) {
             // only one node, skip sorting and just fill the root box

--- a/index.js
+++ b/index.js
@@ -106,8 +106,29 @@ export default class Flatbush {
         return index;
     }
 
+    trim() {
+        const {_boxes, _indices, _pos, minX, minY, maxX, maxY, nodeSize, ArrayType} = this;
+        const numItems = _pos >> 2;
+
+        this.init(numItems, nodeSize, ArrayType);
+
+        this._boxes.set(_boxes.slice(0, this._boxes.length));
+        this._indices.set(_indices.slice(0, this._indices.length));
+
+        this._pos = _pos;
+        this.minX = minX;
+        this.minY = minY;
+        this.maxX = maxX;
+        this.maxY = maxY;
+    }
+
     finish() {
-        if (this._pos >> 2 !== this.numItems) {
+        const numAdded = this._pos >> 2;
+
+        if (numAdded < this.numItems) {
+            this.trim();
+
+        } else if (numAdded > this.numItems) {
             throw new Error(`Added ${this._pos >> 2} items when expected ${this.numItems}.`);
         }
         const boxes = this._boxes;

--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ export default class Flatbush {
     }
 
     constructor(numItems, nodeSize = 16, ArrayType = Float64Array, data) {
+        this.init(numItems, nodeSize, ArrayType, data);
+    }
+
+    init(numItems, nodeSize = 16, ArrayType = Float64Array, data) {
         if (numItems === undefined) throw new Error('Missing required argument: numItems.');
         if (isNaN(numItems) || numItems <= 0) throw new Error(`Unpexpected numItems value: ${numItems}.`);
 

--- a/package.json
+++ b/package.json
@@ -41,12 +41,12 @@
     "flatqueue": "^2.0.3"
   },
   "devDependencies": {
-    "@rollup/plugin-node-resolve": "^13.3.0",
-    "eslint": "^8.23.0",
+    "@rollup/plugin-node-resolve": "^15.0.1",
+    "eslint": "^8.31.0",
     "eslint-config-mourner": "^3.0.0",
     "rbush": "^3.0.1",
     "rbush-knn": "^3.0.1",
-    "rollup": "^2.78.1",
-    "tape": "^5.6.0"
+    "rollup": "^3.10.0",
+    "tape": "^5.6.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.3.0",
-    "eslint": "^8.15.0",
+    "eslint": "^8.23.0",
     "eslint-config-mourner": "^3.0.0",
     "rbush": "^3.0.1",
     "rbush-knn": "^3.0.1",
-    "rollup": "^2.72.1",
-    "tape": "^5.5.3"
+    "rollup": "^2.78.1",
+    "tape": "^5.6.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "pretest": "eslint index.js test.js bench.js",
     "test": "node test.js",
     "build": "rollup index.js -o flatbush.js -n Flatbush -f umd -p node-resolve",
+    "build:esm": "rollup index.js -o flatbush.esm.js -n Flatbush -f esm -p node-resolve",
     "prepublishOnly": "npm run build"
   },
   "files": [
@@ -42,11 +43,11 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "eslint": "^8.31.0",
+    "eslint": "^8.32.0",
     "eslint-config-mourner": "^3.0.0",
     "rbush": "^3.0.1",
     "rbush-knn": "^3.0.1",
     "rollup": "^3.10.0",
-    "tape": "^5.6.1"
+    "tape": "^5.6.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -124,6 +124,14 @@ test('throws an error if added less items than the index size', () => {
     });
 });
 
+test('does not throw an error if added less items than the index size and trim = true', () => {
+    assert.doesNotThrow(() => {
+        const index = new Flatbush(data.length / 4);
+        index.add(data[0], data[1], data[2], data[3]);
+        index.finish(true);
+    });
+});
+
 test('throws an error if searching before indexing', () => {
     assert.throws(() => {
         const index = new Flatbush(data.length / 4);


### PR DESCRIPTION
Fixes #43

hey @mourner,

this diff was the path of least resistance. i think potentially `this._levelBounds` init can be deferred until `finish()`, but is likely minor, though every little bit counts when you're rebuilding the index during a canvas resize/drag :)

i'm not sure there is much reason to require `trim()` be manually invoked as it would just add noise to user code simply to avoid an automatically-avoidable error? you may also be passing the Flatbush instance outside the original context, and then consumers need to know about `trim()` and also how to read back expected length to do the pre-check before invoking `.finish()`...feels awkward.