### PR TITLE
Add SharedArrayBuffer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Alternatively, there's a browser bundle with a `Flatbush` global variable:
 
 ## API
 
-#### `new Flatbush(numItems[, nodeSize, ArrayType, useSharedArrayBuffer])`
+#### `new Flatbush(numItems[, nodeSize, ArrayType, ArrayBufferType])`
 
 Creates a Flatbush index that will hold a given number of items (`numItems`). Additionally accepts:
 

--- a/README.md
+++ b/README.md
@@ -68,13 +68,14 @@ Alternatively, there's a browser bundle with a `Flatbush` global variable:
 
 ## API
 
-#### `new Flatbush(numItems[, nodeSize, ArrayType])`
+#### `new Flatbush(numItems[, nodeSize, ArrayType, useSharedArrayBuffer])`
 
 Creates a Flatbush index that will hold a given number of items (`numItems`). Additionally accepts:
 
 - `nodeSize`: size of the tree node (`16` by default); experiment with different values for best performance (increasing this value makes indexing faster and queries slower, and vise versa).
 - `ArrayType`: the array type used for coordinates storage (`Float64Array` by default);
 other types may be faster in certain cases (e.g. `Int32Array` when your data is integer).
+- `useSharedArrayBuffer`: set `true` if you prefer to use a `SharedArrayBuffer` in place of `ArrayBuffer` (`false` by default). This kind of data structure can be shared between threads.
 
 #### `index.add(minX, minY, maxX, maxY)`
 
@@ -114,9 +115,9 @@ Also accepts a `filterFn` similar to `index.search`.
 
 #### `Flatbush.from(data)`
 
-Recreates a Flatbush index from raw `ArrayBuffer` data
+Recreates a Flatbush index from raw `ArrayBuffer` or `SharedArrayBuffer` data
 (that's exposed as `index.data` on a previously indexed Flatbush instance).
-Very useful for transferring indices between threads or storing them in a file.
+Very useful for transferring or sharing indices between threads or storing them in a file.
 
 ### Properties
 

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Creates a Flatbush index that will hold a given number of items (`numItems`). Ad
 - `nodeSize`: size of the tree node (`16` by default); experiment with different values for best performance (increasing this value makes indexing faster and queries slower, and vise versa).
 - `ArrayType`: the array type used for coordinates storage (`Float64Array` by default);
 other types may be faster in certain cases (e.g. `Int32Array` when your data is integer).
-- `useSharedArrayBuffer`: set `true` if you prefer to use a `SharedArrayBuffer` in place of `ArrayBuffer` (`false` by default). This kind of data structure can be shared between threads.
+- `ArrayBufferType`: the array buffer type used to store data (`ArrayBuffer` by default);
+you may prefer `SharedArrayBuffer` if you want to share the index between threads (multiple `Worker`, `SharedWorker` or `ServiceWorker`).
 
 #### `index.add(minX, minY, maxX, maxY)`
 

--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ export default class Flatbush {
         } while (n !== 1);
 
         this.ArrayType = ArrayType || Float64Array;
-        this.ArrayBufferType = useSharedArrayBuffer ? global.SharedArrayBuffer : ArrayBuffer;
+        this.ArrayBufferType = useSharedArrayBuffer || (data && (global.SharedArrayBuffer && data instanceof global.SharedArrayBuffer)) ? global.SharedArrayBuffer : ArrayBuffer;
         this.IndexArrayType = numNodes < 16384 ? Uint16Array : Uint32Array;
 
         const arrayTypeIndex = ARRAY_TYPES.indexOf(this.ArrayType);

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-
+/* global SharedArrayBuffer */
 import FlatQueue from 'flatqueue';
 
 const ARRAY_TYPES = [
@@ -11,8 +11,8 @@ const VERSION = 3; // serialized format version
 export default class Flatbush {
 
     static from(data) {
-        if (!(data instanceof ArrayBuffer)) {
-            throw new Error('Data must be an instance of ArrayBuffer.');
+        if (!(data instanceof ArrayBuffer) && SharedArrayBuffer && !(data instanceof SharedArrayBuffer)) {
+            throw new Error('Data must be an instance of ArrayBuffer or SharedArrayBuffer.');
         }
         const [magic, versionAndType] = new Uint8Array(data, 0, 2);
         if (magic !== 0xfb) {
@@ -55,7 +55,7 @@ export default class Flatbush {
             throw new Error(`Unexpected typed array class: ${ArrayType}.`);
         }
 
-        if (data && (data instanceof ArrayBuffer)) {
+        if (data && ((data instanceof ArrayBuffer) || (SharedArrayBuffer && data instanceof SharedArrayBuffer))) {
             this.data = data;
             this._boxes = new this.ArrayType(this.data, 8, numNodes * 4);
             this._indices = new this.IndexArrayType(this.data, 8 + nodesByteSize, numNodes);

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ const VERSION = 3; // serialized format version
 export default class Flatbush {
 
     static from(data) {
-        if (data.constructor.name !== 'ArrayBuffer' && data.constructor.name !== 'SharedArrayBuffer') {
+        if (!data || data.byteLength === undefined || data.buffer) {
             throw new Error('Data must be an instance of ArrayBuffer or SharedArrayBuffer.');
         }
         const [magic, versionAndType] = new Uint8Array(data, 0, 2);
@@ -54,7 +54,7 @@ export default class Flatbush {
             throw new Error(`Unexpected typed array class: ${ArrayType}.`);
         }
 
-        if (data && (data.constructor.name === 'ArrayBuffer' || data.constructor.name === 'SharedArrayBuffer')) {
+        if (data && data.byteLength !== undefined && !data.buffer) {
             this.data = data;
             this._boxes = new this.ArrayType(this.data, 8, numNodes * 4);
             this._indices = new this.IndexArrayType(this.data, 8 + nodesByteSize, numNodes);

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-
+/* global SharedArrayBuffer */
 import Flatbush from './index.js';
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -23,8 +23,6 @@ const data = [
     89, 56, 74, 60, 76, 63, 62, 66, 65, 67
 ];
 
-const StoredSharedArrayBuffer = global.SharedArrayBuffer;
-
 function createIndex() {
     const index = new Flatbush(data.length / 4);
 
@@ -46,7 +44,7 @@ function createSmallIndex(numItems, nodeSize) {
 }
 
 function createIndexSharedArrayBuffer() {
-    const index = new Flatbush(data.length / 4, 16, Float64Array, true);
+    const index = new Flatbush(data.length / 4, 16, Float64Array, SharedArrayBuffer);
 
     for (let i = 0; i < data.length; i += 4) {
         index.add(data[i], data[i + 1], data[i + 2], data[i + 3]);
@@ -172,35 +170,15 @@ test('returns index of newly-added rectangle', () => {
 });
 
 test('creates an index using SharedArrayBuffer', () => {
-    enableSharedArrayBuffer();
-
     const index = createIndexSharedArrayBuffer();
     assert(index.data instanceof global.SharedArrayBuffer);
 });
 
-test('throws an error when SharedArrayBuffer is not available', () => {
-    disableSharedArrayBuffer();
-
-    assert.throws(
-        () => createIndexSharedArrayBuffer()
-    );
-});
-
 test('reconstructs an index from shared array buffer', () => {
-    enableSharedArrayBuffer();
-
     const index = createIndexSharedArrayBuffer();
     const index2 = Flatbush.from(index.data);
 
     assert.deepEqual(index, index2);
 });
-
-function disableSharedArrayBuffer() {
-    delete global.SharedArrayBuffer;
-}
-
-function enableSharedArrayBuffer() {
-    global.SharedArrayBuffer = StoredSharedArrayBuffer;
-}
 
 function compare(a, b) { return a - b; }


### PR DESCRIPTION
Hi @mourner,

I hope you, your family and friends are still safe.

This PR adds support for [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) which is a fully compatible alternative to `ArrayBuffer`.

Firstly it allows a `SharedArrayBuffer` to be given to `Flatbush.from()`. Up to now it throws `Data must be an instance of ArrayBuffer`.

Secondly it adds a new optional parameter to the constructor: `useSharedArrayWorker`.

Before to go further, I need to know what do you think of this.

Why use a `SharedArrayBuffer`? You can share the data between multiple workers (`Worker`, `SharedWorker`, `ServiceWorker` and lower memory footprint.
In my use case, the R-tree is big! (~2.5GB).

Jerome