### PR TITLE
Accept `byteOffset` when creating an index from a buffer

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ export default class Flatbush {
     /**
      * Recreate a Flatbush index from raw `ArrayBuffer` or `SharedArrayBuffer` data.
      * @param {ArrayBuffer | SharedArrayBuffer} data
-     * @param {number} byteOffset byte offset to the start of the Flatbush buffer in the referenced ArrayBuffer.
+     * @param {number} [byteOffset=0] byte offset to the start of the Flatbush buffer in the referenced ArrayBuffer.
      * @returns {Flatbush} index
      */
     static from(data, byteOffset = 0) {

--- a/index.js
+++ b/index.js
@@ -23,7 +23,7 @@ export default class Flatbush {
             // @ts-expect-error duck typing array buffers
         } else if (!data || data.byteLength === undefined || data.buffer) {
             throw new Error(
-                'Data must be an instance of Uint8Array,  ArrayBuffer, or SharedArrayBuffer.'
+                'Data must be an instance of Uint8Array, ArrayBuffer, or SharedArrayBuffer.'
             );
         }
 

--- a/index.js
+++ b/index.js
@@ -9,21 +9,19 @@ export default class Flatbush {
 
     /**
      * Recreate a Flatbush index from raw `ArrayBuffer` or `SharedArrayBuffer` data.
-     * @param {Uint8Array | ArrayBuffer | SharedArrayBuffer} data
+     * @param {ArrayBuffer | SharedArrayBuffer} data
+     * @param {number} byteOffset byte offset to the start of the Flatbush buffer in the referenced ArrayBuffer.
      * @returns {Flatbush} index
      */
-    static from(data) {
-        let byteOffset = 0;
-        if (data instanceof Uint8Array) {
-            byteOffset = data.byteOffset;
-            if (byteOffset % 8 !== 0) {
-                throw new Error('Uint8Array offset must be 8-byte aligned.');
-            }
-            data = data.buffer;
-            // @ts-expect-error duck typing array buffers
-        } else if (!data || data.byteLength === undefined || data.buffer) {
+    static from(data, byteOffset = 0) {
+        if (byteOffset % 8 !== 0) {
+            throw new Error('Uint8Array offset must be 8-byte aligned.');
+        }
+
+        // @ts-expect-error duck typing array buffers
+        if (!data || data.byteLength === undefined || data.buffer) {
             throw new Error(
-                'Data must be an instance of Uint8Array, ArrayBuffer, or SharedArrayBuffer.'
+                'Data must be an instance of ArrayBuffer, or SharedArrayBuffer.'
             );
         }
 
@@ -42,14 +40,7 @@ export default class Flatbush {
         const [nodeSize] = new Uint16Array(data, byteOffset + 2, 1);
         const [numItems] = new Uint32Array(data, byteOffset + 4, 1);
 
-        return new Flatbush(
-            numItems,
-            nodeSize,
-            ArrayType,
-            undefined,
-            data,
-            byteOffset
-        );
+        return new Flatbush(numItems, nodeSize, ArrayType, undefined, data, byteOffset);
     }
 
     /**

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ export default class Flatbush {
      */
     static from(data, byteOffset = 0) {
         if (byteOffset % 8 !== 0) {
-            throw new Error('Uint8Array offset must be 8-byte aligned.');
+            throw new Error('byteOffset must be 8-byte aligned.');
         }
 
         // @ts-expect-error duck typing array buffers

--- a/index.js
+++ b/index.js
@@ -20,9 +20,7 @@ export default class Flatbush {
 
         // @ts-expect-error duck typing array buffers
         if (!data || data.byteLength === undefined || data.buffer) {
-            throw new Error(
-                'Data must be an instance of ArrayBuffer, or SharedArrayBuffer.'
-            );
+            throw new Error('Data must be an instance of ArrayBuffer or SharedArrayBuffer.');
         }
 
         const [magic, versionAndType] = new Uint8Array(data, byteOffset + 0, 2);

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ export default class Flatbush {
      * @param {TypedArrayConstructor} [ArrayType=Float64Array] The array type used for coordinates storage (`Float64Array` by default).
      * @param {ArrayBufferConstructor | SharedArrayBufferConstructor} [ArrayBufferType=ArrayBuffer] The array buffer type used to store data (`ArrayBuffer` by default).
      * @param {ArrayBuffer | SharedArrayBuffer} [data] (Only used internally)
-     * @param {number} [byteOffset] (Only used internally)
+     * @param {number} [byteOffset=0] (Only used internally)
      */
     constructor(numItems, nodeSize = 16, ArrayType = Float64Array, ArrayBufferType = ArrayBuffer, data, byteOffset = 0) {
         if (numItems === undefined) throw new Error('Missing required argument: numItems.');

--- a/index.js
+++ b/index.js
@@ -9,15 +9,25 @@ export default class Flatbush {
 
     /**
      * Recreate a Flatbush index from raw `ArrayBuffer` or `SharedArrayBuffer` data.
-     * @param {ArrayBuffer | SharedArrayBuffer} data
+     * @param {Uint8Array | ArrayBuffer | SharedArrayBuffer} data
      * @returns {Flatbush} index
      */
     static from(data) {
-        // @ts-expect-error duck typing array buffers
-        if (!data || data.byteLength === undefined || data.buffer) {
-            throw new Error('Data must be an instance of ArrayBuffer or SharedArrayBuffer.');
+        let byteOffset = 0;
+        if (data instanceof Uint8Array) {
+            byteOffset = data.byteOffset;
+            if (byteOffset % 8 !== 0) {
+                throw new Error('Uint8Array offset must be 8-byte aligned.');
+            }
+            data = data.buffer;
+            // @ts-expect-error duck typing array buffers
+        } else if (!data || data.byteLength === undefined || data.buffer) {
+            throw new Error(
+                'Data must be an instance of Uint8Array,  ArrayBuffer, or SharedArrayBuffer.'
+            );
         }
-        const [magic, versionAndType] = new Uint8Array(data, 0, 2);
+
+        const [magic, versionAndType] = new Uint8Array(data, byteOffset + 0, 2);
         if (magic !== 0xfb) {
             throw new Error('Data does not appear to be in a Flatbush format.');
         }
@@ -29,10 +39,17 @@ export default class Flatbush {
         if (!ArrayType) {
             throw new Error('Unrecognized array type.');
         }
-        const [nodeSize] = new Uint16Array(data, 2, 1);
-        const [numItems] = new Uint32Array(data, 4, 1);
+        const [nodeSize] = new Uint16Array(data, byteOffset + 2, 1);
+        const [numItems] = new Uint32Array(data, byteOffset + 4, 1);
 
-        return new Flatbush(numItems, nodeSize, ArrayType, undefined, data);
+        return new Flatbush(
+            numItems,
+            nodeSize,
+            ArrayType,
+            undefined,
+            data,
+            byteOffset
+        );
     }
 
     /**
@@ -42,13 +59,15 @@ export default class Flatbush {
      * @param {TypedArrayConstructor} [ArrayType=Float64Array] The array type used for coordinates storage (`Float64Array` by default).
      * @param {ArrayBufferConstructor | SharedArrayBufferConstructor} [ArrayBufferType=ArrayBuffer] The array buffer type used to store data (`ArrayBuffer` by default).
      * @param {ArrayBuffer | SharedArrayBuffer} [data] (Only used internally)
+     * @param {number} [byteOffset] (Only used internally)
      */
-    constructor(numItems, nodeSize = 16, ArrayType = Float64Array, ArrayBufferType = ArrayBuffer, data) {
+    constructor(numItems, nodeSize = 16, ArrayType = Float64Array, ArrayBufferType = ArrayBuffer, data, byteOffset = 0) {
         if (numItems === undefined) throw new Error('Missing required argument: numItems.');
         if (isNaN(numItems) || numItems <= 0) throw new Error(`Unexpected numItems value: ${numItems}.`);
 
         this.numItems = +numItems;
         this.nodeSize = Math.min(Math.max(+nodeSize, 2), 65535);
+        this.byteOffset = byteOffset;
 
         // calculate the total number of nodes in the R-tree to allocate space for
         // and the index of each tree level (used in search later)
@@ -74,8 +93,8 @@ export default class Flatbush {
         // @ts-expect-error duck typing array buffers
         if (data && data.byteLength !== undefined && !data.buffer) {
             this.data = data;
-            this._boxes = new this.ArrayType(this.data, 8, numNodes * 4);
-            this._indices = new this.IndexArrayType(this.data, 8 + nodesByteSize, numNodes);
+            this._boxes = new this.ArrayType(this.data, byteOffset + 8, numNodes * 4);
+            this._indices = new this.IndexArrayType(this.data, byteOffset + 8 + nodesByteSize, numNodes);
 
             this._pos = numNodes * 4;
             this.minX = this._boxes[this._pos - 4];

--- a/test.js
+++ b/test.js
@@ -117,6 +117,33 @@ test('reconstructs an index from array buffer', () => {
     assert.deepEqual(index, index2);
 });
 
+test('throws an error when reconstructing an index from array buffer if not 8-byte aligned', () => {
+    const index = createIndex();
+    const newArrayBuffer = new ArrayBuffer(index.data.byteLength + 10);
+    const newView = new Uint8Array(newArrayBuffer, 10);
+    newView.set(new Uint8Array(index.data));
+
+    assert.throws(() => {
+        Flatbush.from(newView);
+    });
+});
+
+test('reconstructs an index from a Uint8Array', () => {
+    const index = createIndex();
+    const newArrayBuffer = new ArrayBuffer(index.data.byteLength + 16);
+    const newView = new Uint8Array(newArrayBuffer, 16);
+    newView.set(new Uint8Array(index.data));
+
+    const index2 = Flatbush.from(newView);
+
+    assert.deepEqual(index._boxes, index2._boxes);
+    assert.deepEqual(index._indices, index2._indices);
+    assert.deepEqual(index.numItems, index2.numItems);
+    assert.deepEqual(index.nodeSize, index2.nodeSize);
+    assert.deepEqual(index._levelBounds, index2._levelBounds);
+    assert.notDeepEqual(index.byteOffset, index2.byteOffset);
+});
+
 test('throws an error if added less items than the index size', () => {
     assert.throws(() => {
         const index = new Flatbush(data.length / 4);

--- a/test.js
+++ b/test.js
@@ -119,22 +119,24 @@ test('reconstructs an index from array buffer', () => {
 
 test('throws an error when reconstructing an index from array buffer if not 8-byte aligned', () => {
     const index = createIndex();
-    const newArrayBuffer = new ArrayBuffer(index.data.byteLength + 10);
-    const newView = new Uint8Array(newArrayBuffer, 10);
+    const byteOffset = 12;
+    const newArrayBuffer = new ArrayBuffer(index.data.byteLength + byteOffset);
+    const newView = new Uint8Array(newArrayBuffer, byteOffset);
     newView.set(new Uint8Array(index.data));
 
     assert.throws(() => {
-        Flatbush.from(newView);
+        Flatbush.from(newArrayBuffer, byteOffset);
     });
 });
 
 test('reconstructs an index from a Uint8Array', () => {
     const index = createIndex();
-    const newArrayBuffer = new ArrayBuffer(index.data.byteLength + 16);
-    const newView = new Uint8Array(newArrayBuffer, 16);
+    const byteOffset = 16;
+    const newArrayBuffer = new ArrayBuffer(index.data.byteLength + byteOffset);
+    const newView = new Uint8Array(newArrayBuffer, byteOffset);
     newView.set(new Uint8Array(index.data));
 
-    const index2 = Flatbush.from(newView);
+    const index2 = Flatbush.from(newArrayBuffer, byteOffset);
 
     assert.deepEqual(index._boxes, index2._boxes);
     assert.deepEqual(index._indices, index2._indices);

--- a/test.js
+++ b/test.js
@@ -140,10 +140,10 @@ test('reconstructs an index from a Uint8Array', () => {
 
     assert.deepEqual(index._boxes, index2._boxes);
     assert.deepEqual(index._indices, index2._indices);
-    assert.deepEqual(index.numItems, index2.numItems);
-    assert.deepEqual(index.nodeSize, index2.nodeSize);
+    assert.equal(index.numItems, index2.numItems);
+    assert.equal(index.nodeSize, index2.nodeSize);
     assert.deepEqual(index._levelBounds, index2._levelBounds);
-    assert.notDeepEqual(index.byteOffset, index2.byteOffset);
+    assert.notEqual(index.byteOffset, index2.byteOffset);
 });
 
 test('throws an error if added less items than the index size', () => {


### PR DESCRIPTION
Closes https://github.com/mourner/flatbush/issues/54

### Change list

- Allows `Uint8Array` input in `Flatbush.from`
- Throws if `Uint8Array` is not 8-byte aligned. When `ArrayType` is not Float64, maybe the alignment requirement could be less strict.
- Uses `byteOffset` when creating views on the input ArrayBuffer
- Adds `byteOffset` argument to constructor.
- Adds test that throws when alignment is incorrect and test that succeeds when alignment is correct.